### PR TITLE
Fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We may have missed a keyboard shortcut. If we did please help us out! It is very
 
 1. Head over to our [GitHub repository](https://github.com/waderyan/vscode-atom-keybindings). 
 2. Open [`package.json`](https://github.com/waderyan/vscode-atom-keybindings/blob/master/package.json). 
-3. Add a JSON object to [`contributions.keybindings`](https://github.com/waderyan/vscode-atom-keybindings/blob/master/package.json#L25) as seen below. 
+3. Add a JSON object to [`contributes.keybindings`](https://github.com/waderyan/vscode-atom-keybindings/blob/master/package.json#L25) as seen below. 
 4. Open a pull request. 
 
 ```json


### PR DESCRIPTION
JSON object in `package.json` file is `contributes.keybindings`, not `contributions.keybindings`.