### PR TITLE
Keybindings for mac

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,9 +70,15 @@
                 "command": "workbench.action.splitEditor"
             },
             {
+                "mac": "cmd+t",
                 "win": "ctrl+t",
                 "key": "ctrl+p",
                 "command": "workbench.action.quickOpen"
+            },
+            {
+                "mac": "ctrl-alt-b",
+                "key": "shift-alt-f",
+                "command": "editor.action.formatDocument"
             },
             {
                 "mac": "cmd+b",
@@ -193,7 +199,7 @@
                 "command": "workbench.action.gotoSymbol"
             },
             {
-                "mac": "ctrl+cmd+[",
+                "mac": "alt+cmd+[",
                 "win": "ctrl+alt+/",
                 "linux": "ctrl+alt+/",
                 "key": "ctrl+alt+/",
@@ -201,7 +207,7 @@
                 "when": "editorTextFocus"
             },
             {
-                "mac": "ctrl+cmd+]",
+                "mac": "alt+cmd+]",
                 "win": "ctrl+alt+/",
                 "linux": "ctrl+alt+/",
                 "key": "ctrl+alt+/",
@@ -217,12 +223,34 @@
                 "when": "editorTextFocus"
             },
             {
+                "mac": "cmd+shift+7",
+                "key": "cmd+k cmd+c",
+                "command": "editor.action.commentLine",
+                "when": "editorTextFocus"
+            },
+            {
                 "mac": "alt+shift+cmd+]",
                 "win": "ctrl+alt+]",
                 "linux": "ctrl+alt+]",
                 "key": "ctrl+alt+]",
                 "command": "editor.unfoldAll",
                 "when": "editorTextFocus"
+            },
+            {
+                "mac": "cmd+k cmd-0",
+                "key": "ctrl+alt+]",
+                "command": "editor.unfoldAll",
+                "when": "editorTextFocus"
+            },
+            {
+                "mac": "cmd+-",
+                "key": "ctrl+=",
+                "command": "workbench.action.zoomIn"
+            },
+            {
+                "mac": "cmd+/",
+                "key": "ctrl+-",
+                "command": "workbench.action.zoomOut"
             },
             {
                 "mac": "cmd+k cmd+1",
@@ -361,9 +389,9 @@
                 "linux": "alt+9",
                 "key": "alt+9",
                 "command": "workbench.action.openEditorAtIndex9"
-            }, 
+            },
             {
-                "mac": "cmd+shift+\\",
+                "mac": "alt+cmd+\\",
                 "win": "ctrl+shift+\\",
                 "linux": "ctrl+shift+\\",
                 "key": "ctrl+shift+\\",


### PR DESCRIPTION
Here're some mac bindings from Atom. I've included sources to why I picked a particular binding.

- OS X 10.12.1
- Atom 1.11.2
- Visual Studio Code 1.7.1

## workbench.action.quickOpen

This is [the official](https://atom.io/packages/fuzzy-finder) `cmd-t` package for atom, even tho it isn't marked with `Core` as most of the others are.

![fuzzy-finder-file](https://cloud.githubusercontent.com/assets/220827/20001857/4f19bcb8-a27e-11e6-8649-f12cceef3fbb.png)

## editor.action.formatDocument

Third party source: [atom-beautify](https://atom.io/packages/atom-beautify) with 1.9M downloads.

![bea](https://cloud.githubusercontent.com/assets/220827/20001873/59504ddc-a27e-11e6-9c2e-eeb3332bbada.png)

## editor.action.commentLine

This one is a bit tricky. On my Swedish keyboard, `cmd+/` focuses the search function in the `Help` menu bar. This seems to be a problem on non US/GB (?) keyboards ([source](http://stackoverflow.com/questions/34316156/how-to-comment-multiple-lines-in-visual-studio-code#comment65868339_34317039)). The solution is to use `cmd+shift+7` as `shift+7` normally yields `/`.

![focus-help](https://cloud.githubusercontent.com/assets/220827/20001893/6cd67552-a27e-11e6-9e8c-cb79c5544cc0.png)

![comment](https://cloud.githubusercontent.com/assets/220827/20001898/7234399e-a27e-11e6-8540-628038a0d05d.png)

## workbench.action.files.openFileFolder

There isn't much documentation on this, but it looks like `workbench.action.files.openFileFolder` opens a new project.

![workbench action files openfilefolder](https://cloud.githubusercontent.com/assets/220827/20001940/9ee84ff2-a27e-11e6-83a9-3c785cabca56.png)

## workbench.action.zoomIn

This is a bit backwards on my machine. `cmd++` maps to `cmd+-` and `cmd+=` can't be mapped.

![in](https://cloud.githubusercontent.com/assets/220827/20001979/ced053ea-a27e-11e6-9906-1fb1ef76d177.png)

## workbench.action.zoomOut

`cmd+_` Isn't supported on my keyboard.

![out](https://cloud.githubusercontent.com/assets/220827/20001967/bf452f04-a27e-11e6-84d1-279ab4f41e92.png)

## workbench.files.action.showActiveFileInExplorer

![showactivefileinexplorer](https://cloud.githubusercontent.com/assets/220827/20002001/e361ccf8-a27e-11e6-9c0f-6af22cf5f985.png)

## editor.unfoldAll

![editor unfoldal](https://cloud.githubusercontent.com/assets/220827/20002018/ee958b0a-a27e-11e6-9441-ded3915d76ea.png)

## editor.fold

![fold](https://cloud.githubusercontent.com/assets/220827/20002027/fe8f27b4-a27e-11e6-9d5b-45463626efd3.png)

## editor.unfold

![unfold](https://cloud.githubusercontent.com/assets/220827/20002031/063524c8-a27f-11e6-8b03-bc83fbdce15e.png)