### PR TITLE
Fixes the comment keybinding

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,7 +257,7 @@
                 "command": "workbench.action.zoomIn"
             },
             {
-                "mac": "cmd+/",
+                "mac": "cmd++",
                 "key": "ctrl+-",
                 "command": "workbench.action.zoomOut"
             },


### PR DESCRIPTION
In atom, `cmd + /` is used to comment a line of code.

Addresses #22