### PR TITLE
Add mac specific shorcut for sidebar visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
                 "command": "workbench.action.toggleSidebarVisibility"
             },
             {
+                "mac": "cmd+\\",
                 "win": "ctrl+\\",
                 "linux": "ctrl+\\",
                 "key": "ctrl+\\",


### PR DESCRIPTION

Command palette from Atom showing ⌘\ as the keybinding

<img width="625" alt="atom mac keybinding for toggling tree view" src="https://cloud.githubusercontent.com/assets/1895895/24580466/707ef928-16d6-11e7-8fe5-a63d3a94c67a.png">